### PR TITLE
docs: Fix default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 require("monet").setup {
     transparent_background = false,
     semantic_tokens = true,
-    dark_mode = false,
+    dark_mode = true,
     highlight_overrides= {},
     color_overrides = {},
     styles = {},


### PR DESCRIPTION
According to https://github.com/fynnfluegge/monet.nvim/blob/e358f6b0035932c6faad8cd4157e4dd2272f88a2/lua/monet/config.lua#L4

`dark_mode` seems default `true`.

